### PR TITLE
feat: Add MongoDB Shell (mongosh) support and update m to v1.10.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,4 +19,4 @@ jobs:
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v2
         with:
-          command: mongodb --help
+          command: mongod --help

--- a/README.md
+++ b/README.md
@@ -15,10 +15,7 @@
 
 # Dependencies
 
-**TODO: adapt this section**
-
 - `bash`, `curl`, `tar`, and [POSIX utilities](https://pubs.opengroup.org/onlinepubs/9699919799/idx/utilities.html).
-- `SOME_ENV_VAR`: set this environment variable in your shell config to load the correct version of tool x.
 
 # Install
 
@@ -43,7 +40,7 @@ asdf install mongodb latest
 asdf global mongodb latest
 
 # Now mongodb commands are available
-mongodb --help
+mongod --help
 ```
 
 Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 # asdf-mongodb [![Build](https://github.com/jarjee/asdf-mongodb/actions/workflows/build.yml/badge.svg)](https://github.com/jarjee/asdf-mongodb/actions/workflows/build.yml) [![Lint](https://github.com/jarjee/asdf-mongodb/actions/workflows/lint.yml/badge.svg)](https://github.com/jarjee/asdf-mongodb/actions/workflows/lint.yml)
 
-[mongodb](https://github.com/jarjee/asdf-mongodb) plugin for the [asdf version manager](https://asdf-vm.com).
+[MongoDB](https://www.mongodb.com) plugin for the [asdf version manager](https://asdf-vm.com).
+
+Installs `mongod`, `mongos`, and related CLI tools. Backed by [aheckmann/m](https://github.com/aheckmann/m).
 
 </div>
 
@@ -27,7 +29,7 @@ asdf plugin add mongodb
 asdf plugin add mongodb https://github.com/jarjee/asdf-mongodb.git
 ```
 
-mongodb:
+MongoDB:
 
 ```shell
 # Show all installable versions
@@ -39,8 +41,12 @@ asdf install mongodb latest
 # Set a version globally (on your ~/.tool-versions file)
 asdf global mongodb latest
 
-# Now mongodb commands are available
+# Now MongoDB commands are available
 mongod --help
+mongos --help
+
+# Uninstall a version
+asdf uninstall mongodb <version>
 ```
 
 Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to
@@ -48,7 +54,7 @@ install & manage versions.
 
 # Contributing
 
-Contributions of any kind welcome! See the [contributing guide](contributing.md).
+Contributions of any kind welcome! Open an issue or pull request on [GitHub](https://github.com/jarjee/asdf-mongodb).
 
 [Thanks goes to these contributors](https://github.com/jarjee/asdf-mongodb/graphs/contributors)!
 

--- a/bin/download
+++ b/bin/download
@@ -1,17 +1,4 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
-current_script_path=${BASH_SOURCE[0]}
-plugin_dir=$(dirname "$(dirname "$current_script_path")")
-
-# shellcheck source=./lib/utils.bash
-source "${plugin_dir}/lib/utils.bash"
-
-mkdir -p "$ASDF_DOWNLOAD_PATH"
-
-# Download tar.gz file to the download directory
-download_release "$ASDF_INSTALL_VERSION" "release_file"
-
-#  Extract contents of tar.gz file into the download directory
-# tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" --strip-components=1 || fail "Could not extract $release_file"
+# lib/m handles downloading as part of the install step.
+# This hook is intentionally a no-op.

--- a/bin/help.deps
+++ b/bin/help.deps
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "curl, tar"

--- a/bin/help.links
+++ b/bin/help.links
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+echo "MongoDB downloads: https://www.mongodb.com/try/download/community"
+echo "Release notes:     https://www.mongodb.com/docs/manual/release-notes/"
+echo "m (version mgr):   https://github.com/aheckmann/m"
+echo "This plugin:       https://github.com/jarjee/asdf-mongodb"

--- a/bin/help.overview
+++ b/bin/help.overview
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "MongoDB server (mongod), router (mongos), and CLI tools."
+echo "Backed by aheckmann/m — the MongoDB version manager."

--- a/bin/install
+++ b/bin/install
@@ -8,4 +8,4 @@ plugin_dir=$(dirname "$(dirname "$current_script_path")")
 # shellcheck source=./lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
-# install_version "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
+install_version "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/post-plugin-add
+++ b/bin/post-plugin-add
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "asdf-mongodb: run 'asdf install mongodb latest' to install the latest stable release."
+echo "             run 'asdf list-all mongodb' to see all available versions."

--- a/bin/uninstall
+++ b/bin/uninstall
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
+# shellcheck source=./lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
+
+rm -rf "$ASDF_INSTALL_PATH"
+echo "$TOOL_NAME $ASDF_INSTALL_VERSION uninstalled."

--- a/lib/m
+++ b/lib/m
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#\!/usr/bin/env bash
 # shellcheck disable=all
-# Copied from hash 95a0a7faa9c0e23e05148b20d2906281ac85cebd of https://github.com/aheckmann/m
+# Copied from hash 69d3c937a2b261ed7ed941d1636a39a4cf8dab33 of https://github.com/aheckmann/m
 
 ### Configuration
 
@@ -22,6 +22,9 @@ VERSIONS_DIR=$M_DIR/versions
 # Directory for MongoDB Tools version binaries
 TOOLS_DIR=$M_DIR/tools/versions
 
+# Directory for MongoDB Shell version binaries
+SHELL_DIR=$M_DIR/shell/versions
+
 # Working directory for unpacking MongoDB tarballs
 BUILD_DIR_BASE=$M_DIR/mongo-
 
@@ -41,7 +44,7 @@ CACHE_SRC=${M_CACHE_SRC:-$M_DIR/cache-src.json}
 CACHE_EXPIRY=${M_CACHE_EXPIRY:-3600}
 
 # m version
-VERSION="1.8.9"
+VERSION="1.10.0"
 
 #
 # Log the given <msg ...>
@@ -83,6 +86,14 @@ abort_not_installed() {
   exit 1
 }
 
+abort_shell_not_installed() {
+  printf "Error: The requested MongoDB shell version is not installed.\n"
+  if [[ ! -z "$version" ]]; then
+    printf "Try 'm mongosh $version' to download and activate.\n"
+  fi
+  exit 1
+}
+
 #
 # Check file age (in seconds)
 #
@@ -109,10 +120,9 @@ GET=
 which wget >/dev/null 2>&1 && GET="wget -q -O-"
 
 # curl support
-which curl >/dev/null 2>&1 && GET="curl -s -L"
+which curl >/dev/null 2>&1 && GET="curl -sSLf"
 
 # Ensure we have curl or wget
-
 test -z "$GET" && abort "curl or wget required"
 
 #
@@ -130,7 +140,7 @@ display_help() {
     m                            Output versions installed
     m stable [config ...]        Install or activate the latest stable MongoDB release
     m latest [config ...]        Install or activate the latest MongoDB release (including dev & RCs)
-    m X.Y                        Install or activate the latest patch release for MongoDB X.Y (eg. 3.6)
+    m X.Y                        Install or activate the latest patch release for MongoDB X.Y (eg. 7.0)
     m <version> [config ...]     Install and/or use MongoDB <version>
     m reinstall <version>        Remove and reinstall MongoDB <version>
     m <version> --legacy         Install generic Linux version (does not include SSL)
@@ -140,9 +150,9 @@ display_help() {
     m bin <version>              Output bin path for <version>
     m rm <version ...>           Remove the given version(s)
     m --stable                   Output the latest stable MongoDB version available
-    m --stable X.Y                .. for release series X.Y (eg. 3.6)
+    m --stable X.Y                .. for release series X.Y (eg. 7.0)
     m --latest                   Output the latest MongoDB version available (including dev & RCs)
-    m --latest X.Y                .. for release series X.Y (eg. 3.6)
+    m --latest X.Y                .. for release series X.Y (eg. 7.0)
     m ls                         Output the versions of MongoDB available
     m installed [--json]         Output installed versions available (optionally, in JSON format)
     m src <version>              Output the url for source used for the given <version>
@@ -154,14 +164,20 @@ display_help() {
     m pre <event> rm [script]    Remove pre <event> script
     m post <event> rm [script]   Remove post <event> script
     m tools stable               Install or activate the latest stable Database Tools release
-    m tools X.Y.Z                Install or activate the Database Tools X.Y.Z 
+    m tools X.Y.Z                Install or activate the Database Tools X.Y.Z
     m tools ls                   Output the versions of the Database Tools available
-    m tools installed [--json]   Output installed versions of the Database Tools available
+    m tools rm <version ...>     Remove the given Database Tools versions
+    m tools installed [--json]   Output the installed versions of the Database Tools
+    m mongosh stable             Install or activate the latest stable MongoDB Shell release
+    m mongosh X.Y.Z              Install or activate the MongoDB Shell X.Y.Z
+    m mongosh ls                 Output the versions of the MongoDB Shell available
+    m mongosh rm <version ...>   Remove the given MongoDB Shell versions
+    m mongosh installed [--json] Output the installed versions of the MongoDB Shell
 
   Events:
 
-    change   Occurs when switching MongoDB versions
-    install  Occurs when installing a previously uninstalled MongoDB version
+    change   Occurs when switching MongoDB server versions
+    install  Occurs when installing a previously uninstalled MongoDB server version
 
   Options:
 
@@ -195,27 +211,27 @@ display_m_version() {
 #
 
 get_all_versions() {
-    local src_url="https://downloads.mongodb.org/full.json"
+  local src_url="https://downloads.mongodb.org/full.json"
 
-    if [ $CACHE == 1 ]; then
-        # Use the cached versions if valid
-        if [ -e $CACHE_SRC ]; then
-          debug "$CACHE_SRC is $(file_age_in_seconds $CACHE_SRC) seconds old (expiry: $CACHE_EXPIRY)"
-          if [ $(file_age_in_seconds $CACHE_SRC) -lt $CACHE_EXPIRY ]; then
-            debug "Using cache: $CACHE_SRC"
-            all_versions=`cat $CACHE_SRC`
-          fi
-        fi
-    fi
-
-    if [ -z "$all_versions" ]; then
-      debug "get_all_versions(): $GET $src_url"
-      all_versions=`$GET 2> /dev/null $src_url`
-      if [ $CACHE ]; then
-        debug "Creating cache: $CACHE_SRC"
-        echo "$all_versions" > $CACHE_SRC
+  if [ $CACHE == 1 ]; then
+    # Use the cached versions if valid
+    if [ -e $CACHE_SRC ]; then
+      debug "$CACHE_SRC is $(file_age_in_seconds $CACHE_SRC) seconds old (expiry: $CACHE_EXPIRY)"
+      if [ $(file_age_in_seconds $CACHE_SRC) -lt $CACHE_EXPIRY ]; then
+        debug "Using cache: $CACHE_SRC"
+        all_versions=`cat $CACHE_SRC`
       fi
     fi
+  fi
+
+  if [ -z "$all_versions" ]; then
+    debug "get_all_versions(): $GET $src_url"
+    all_versions=`$GET $src_url`
+    if [ $CACHE ]; then
+      debug "Creating cache: $CACHE_SRC"
+      echo "$all_versions" > $CACHE_SRC
+    fi
+  fi
 }
 
 #
@@ -223,10 +239,11 @@ get_all_versions() {
 #
 
 check_current_version() {
-  which mongo &> /dev/null
+  which $M_BIN_DIR/mongod &> /dev/null
   if test $? -eq 0; then
-    active=`mongod --version | grep "version\s*v[0-9]" | grep -E -o '[0-9]+\.[0-9]+\.[0-9]+([-_\.][a-zA-Z0-9]+)?' | head -1`
-    ent=`mongod --version | grep -E "(modules:\s*)|\"enterprise\"?" | wc -l`
+    active=`$M_BIN_DIR/mongod --version | grep "version\s*v[0-9]" | grep -E -o '[0-9]+\.[0-9]+\.[0-9]+([-_\.][a-zA-Z0-9]+)?' | head -1`
+    # either has "modules" set to something other than none or [], or includes the string "enterprise"
+    ent=`$M_BIN_DIR/mongod --version | grep -E '(modules\"?:|\"?enterprise\"?)' | grep -v -E 'modules"?:[[:space:]]*\[.*' | grep -v -E 'modules"?:[[:space:]]*none'`
     if [[ $ent == *1 ]]; then
       active="$active-ent"
     fi
@@ -242,16 +259,23 @@ display_versions() {
   local option=$1; shift
   local json=false
 
+  if test "$option" = "--json"; then
+    json=true
+  fi
+
   declare -a versions
   versions=(`ls -1 $VERSIONS_DIR | sort -t. -k 1,1n -k 2,2n -k 3,3n`)
   if test -z "$versions"; then
-    echo No installed versions
+    if $json; then
+      echo "[]"
+    else
+      echo "No installed versions"
+    fi
     return
   fi
   local last=${versions[${#versions[@]}-1]}
 
-  if test "$option" = "--json"; then
-    json=true
+  if $json; then
     printf "["
   fi
 
@@ -267,7 +291,7 @@ display_versions() {
       fi
     else
       if [ "$version" = "$active" ]; then
-        printf "  * $version $config\n"
+        printf "  ✔ $version $config\n"
       else
         printf "    $version $config\n"
       fi
@@ -280,8 +304,8 @@ display_versions() {
 }
 
 #
-# Install and activate MongoDB Database Tools. 
-# Will install the full server for version <4.3.2 since the tools 
+# Install and activate MongoDB Database Tools.
+# Will install the full server for version <4.3.2 since the tools
 # are included with the server for those versions.
 #
 #   install_tools <version>
@@ -302,7 +326,7 @@ install_tools() {
     local rc="--rc"
   fi
   get_all_tools_versions $rc
-  
+
   if [[ $version == "stable" ]]; then
     # Set version to the latest available version
     version=`echo $versions | awk 'NF>1{print $NF}'`
@@ -362,30 +386,31 @@ install_tools_bin() {
   log "installing binary"
 
   ext="tgz"
-  get_distro_and_arch
+  get_distro_and_arch 'tools'
   if [[ $os = "linux" ]]; then
     # for linux fetch the rhel7 tarball by default
     local dist=rhel70
     # shadowing earlier $distro
     for distro in $distros; do
-      if good "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-$distro-$arch-$version.tgz"; then
+      if good "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-$distro-$arch-$version.$ext"; then
         dist=$distro
         break
       fi
     done
-  fi
-  if [[ $os = "osx" ]]; then
+  elif [[ $os = "osx" ]]; then
     dist="macos"
     if vergte $version "100.1.0"; then
       ext="zip"
     fi
-    if [ "$arch" = "arm64" ]; then
-      echo ""
-      echo "NOTE: Apple Silicon is not natively supported for MongoDB Database Tools"
-      echo " ==> Changing detected architecture from arm64 to x86_64 so Rosetta 2 can be used"
-      echo "     More info: https://support.apple.com/en-au/HT211861"
-      echo ""
-      arch="x86_64"
+    if [[ "$arch" = "arm64" ]]; then
+      if verlte "$version" "100.7.0"; then
+        echo ""
+        echo "NOTE: Apple Silicon is not natively supported for this version of MongoDB Database Tools"
+        echo " ==> Changing detected architecture from arm64 to x86_64 so Rosetta 2 can be used"
+        echo "     More info: https://support.apple.com/en-au/HT211861"
+        echo ""
+        arch="x86_64"
+      fi
     fi
   fi
 
@@ -394,7 +419,7 @@ install_tools_bin() {
   $GET https://fastdl.mongodb.org/tools/db/mongodb-database-tools-$dist-$arch-$version.$ext -o $M_DIR/tools-$version.$ext
   if test $? -gt 0; then
     printf "Error: tools installation failed\n"
-    printf "  Tarball fetch for MongoDB tools version $version failed.\n"
+    printf "  Fetch for MongoDB tools version $version failed.\n"
     printf "  Try a different version or view $logpath to view\n"
     printf "  error details.\n"
     exit 1
@@ -402,7 +427,7 @@ install_tools_bin() {
   mkdir -p $TOOLS_DIR/$version
   if [[ $ext = "zip" ]]; then
     unzip -q $M_DIR/tools-$version.zip -d $TOOLS_DIR/$version
-  else 
+  else
     tar -xzf $M_DIR/tools-$version.tgz -C $TOOLS_DIR/$version
   fi
   mv $TOOLS_DIR/$version/mongodb-database-tools-$dist-$arch-$version/* $TOOLS_DIR/$version
@@ -417,10 +442,10 @@ install_tools_bin() {
 #
 
 check_current_tools_version() {
-  which mongodump &> /dev/null
+  which $M_BIN_DIR/mongodump &> /dev/null
   if test $? -eq 0; then
     # Note: this regex only works for mongodump 3.0+
-    active_tools=`mongodump --version | sed -nE "s/mongodump version\: r?(.*)$/\1/p"`
+    active_tools=`$M_BIN_DIR/mongodump --version | sed -nE "s/mongodump version\: r?(.*)$/\1/p"`
   fi
 }
 
@@ -437,11 +462,16 @@ get_all_tools_versions() {
     local rc_regex="(-rc[0-9]+)?"
   fi
 
-  tools_versions=`curl -s \
-  -H "Accept: application/vnd.github.v3+json" \
-  https://api.github.com/repos/mongodb/mongo-tools/git/refs/tags \
+  curl_tools_versions=(curl -sSf -H "Accept: application/vnd.github.v3+json")
+  if [ -n "${GH_TOKEN:-}" ]; then
+    debug "Using GitHub token from environment for API requests"
+    curl_tools_versions+=(-H "authorization: bearer ${GH_TOKEN:?}")
+  fi
+  curl_tools_versions+=("https://api.github.com/repos/mongodb/mongo-tools/git/refs/tags")
+
+  tools_versions="$("${curl_tools_versions[@]}" \
   | sed -nE "s/^.*\"ref\"\: \"refs\/tags\/r?([[:digit:]]{2,3}\.[[:digit:]]+\.[[:digit:]]+)\",$/\1/p" \
-  | sort -V`
+  | sort -V)"
 
   get_all_versions
 
@@ -470,7 +500,7 @@ list_tools_versions() {
 
   for v in $versions; do
     if test "$active_tools" = "$v"; then
-      printf "   $v\n"
+      printf "  ✔ $v\n"
     else
       if test -d $VERSIONS_DIR/$v || test -d $TOOLS_DIR/$v; then
         printf "  * $v\n"
@@ -513,20 +543,27 @@ verlt() {
 display_tools_versions() {
   local option=$1; shift
   local json=false
+  if test "$option" = "--json"; then
+    json=true
+  fi
 
   declare -a versions
   if [ -e $TOOLS_DIR ]; then
     versions=(`(ls -1 $VERSIONS_DIR; ls -1 $TOOLS_DIR) | sort -t. -k 1,1n -k 2,2n -k 3,3n`)
   fi
 
+
   if test -z "$versions"; then
-    echo "No installed versions"
+    if $json; then
+      echo "[]"
+    else
+      echo "No installed versions"
+    fi
     return
   fi
   local last=${versions[${#versions[@]}-1]}
 
-  if test "$option" = "--json"; then
-    json=true
+  if $json; then
     printf "["
   fi
 
@@ -545,7 +582,7 @@ display_tools_versions() {
       fi
     else
       if [ "$version" = "$active_tools" ]; then
-        printf "   $version $config\n"
+        printf "  ✔ $version $config\n"
       else
         printf "    $version $config\n"
       fi
@@ -557,12 +594,316 @@ display_tools_versions() {
   fi
 }
 
+remove_tools_versions() {
+  test -z $1 && abort "version(s) required"
+  check_current_tools_version
+
+  while test $# -ne 0; do
+    local version=${1#v}
+    local rmpath="$TOOLS_DIR/$version"
+    debug "=> Path: $rmpath"
+
+    if verlte $version "4.3.2"; then
+      printf "Error: Cannot remove tools version $version since it is included with the\n"
+      printf "MongoDB server package. To remove this version, remove the server instead:\n"
+      printf "   m rm $version\n"
+      shift
+      continue
+    fi
+
+    if test "$version" = "$active_tools"; then
+      printf "WARNING: $version is the active version!\n"
+      if [[ "$CONFIRM" == 1 ]]; then
+        read -p "Are you sure you want to remove this? [y/N] " yn
+        case $yn in
+          [Yy]* ) ;;
+          * )  printf "SKIPPING $version "; exit;;
+        esac
+      fi
+    fi
+
+    if [ -d $rmpath ]; then
+      rm -rf $rmpath
+      echo "Removed MongoDB tools version $version"
+      active_tools=""
+    else
+      echo "MongoDB tools version $version is not installed"
+    fi
+
+    shift
+  done
+}
+
+#
+# Find the current installed version of shell.
+#
+
+check_current_shell_version() {
+  which $M_BIN_DIR/mongosh &> /dev/null
+  if test $? -eq 0; then
+    active_shell=`$M_BIN_DIR/mongosh --version | sed -nE "s/^([0-9]+\.[0-9]+\.[0-9]+)$/\1/p" | head -1`
+  fi
+}
+
+#
+# Find all available versions of the MongoDB Shell.
+#
+
+get_all_shell_versions() {
+  local rc_regex=""
+  if [[ $1 == "--rc" ]]; then
+    rc_regex="(-rc[0-9]+)?"
+  fi
+
+  curl_shell_versions=(curl -sSf -H "Accept: application/vnd.github.v3+json")
+  if [ -n "${GH_TOKEN:-}" ]; then
+    debug "Using GitHub token from environment for API requests"
+    curl_shell_versions+=(-H "authorization: bearer ${GH_TOKEN:?}")
+  fi
+  curl_shell_versions+=("https://api.github.com/repos/mongodb-js/mongosh/git/refs/tags")
+
+  shell_versions="$("${curl_shell_versions[@]}" \
+  | sed -nE "s/^.*\"ref\"\: \"refs\/tags\/v([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$rc_regex)\",$/\1/p" \
+  | sort -V)"
+
+  versions="$shell_versions"
+}
+
+#
+# Output all MongoDB Shell versions
+#
+
+list_shell_versions() {
+  check_current_shell_version
+
+  if [[ $2 == "--rc" ]]; then
+    local rc="--rc"
+  fi
+
+  get_all_shell_versions $rc
+
+  for v in $versions; do
+    if test "$active_shell" = "$v"; then
+      printf "  ✔ $v\n"
+    else
+      if test -d $SHELL_DIR/$v; then
+        printf "  * $v\n"
+      else
+        printf "    $v\n"
+      fi
+    fi
+  done
+}
+
+#
+# Output all installed shell versions.
+# Pass "--json" to output in JSON format.
+#
+
+display_shell_versions() {
+  local option=$1; shift
+  local json=false
+  if test "$option" = "--json"; then
+    json=true
+  fi
+
+  declare -a versions
+  if [ -e $SHELL_DIR ]; then
+    versions=(`ls -1 $SHELL_DIR | sort -t. -k 1,1n -k 2,2n -k 3,3n`)
+  fi
+
+  if test -z "$versions"; then
+    if $json; then
+      echo "[]"
+    else
+      echo "No installed versions"
+    fi
+    return
+  fi
+  local last=${versions[${#versions[@]}-1]}
+
+  if $json; then
+    printf "["
+  fi
+
+  check_current_shell_version
+  for version in ${versions[@]}; do
+    local dir="$SHELL_DIR/$version"
+    local config=`test -f "$dir"/.config && cat "$dir"/.config`
+    if $json; then
+      printf "\n  {\n    \"name\" : \"$version\",\n    \"path\" : \"$dir/bin/\" \n  }"
+      if [ "$version" != "$last" ]; then
+        printf ","
+      fi
+    else
+      if [ "$version" = "$active_shell" ]; then
+        printf "  ✔ $version $config\n"
+      else
+        printf "    $version $config\n"
+      fi
+    fi
+  done
+
+  if $json; then
+    printf "\n]\n"
+  fi
+}
+
+remove_shell_versions() {
+  test -z $1 && abort "version(s) required"
+  check_current_shell_version
+
+  while test $# -ne 0; do
+    local version=${1#v}
+    local rmpath="$SHELL_DIR/$version"
+    debug "=> Path: $rmpath"
+    if test "$version" = "$active_shell"; then
+      printf "WARNING: $version is the active version!\n"
+      if [[ "$CONFIRM" == 1 ]]; then
+        read -p "Are you sure you want to remove this? [y/N] " yn
+        case $yn in
+          [Yy]* ) ;;
+          * )  printf "SKIPPING $version "; exit;;
+        esac
+      fi
+    fi
+
+    if [ -d $rmpath ]; then
+      rm -rf $rmpath
+      echo "Removed MongoDB shell version $version"
+      active_shell=""
+    else
+      echo "MongoDB shell version $version is not installed"
+    fi
+
+    shift
+  done
+}
+
+#
+# Install MongoDB Shell binaries for provided version
+#
+#   install_shell_bin <version>
+#
+
+install_shell_bin() {
+  local version=$1
+
+  log "installing mongosh $version"
+
+  ext="tgz"
+  get_distro_and_arch 'shell'
+
+  if [[ $os = "linux" ]]; then
+    dist="linux"
+  fi
+
+  if [[ $os = "osx" ]]; then
+    dist="darwin"
+    ext="zip"
+  fi
+
+  if [[ $arch = "x86_64" ]]; then
+    # For mongosh, use x64 naming, following this doc:
+    # https://s3.amazonaws.com/info-mongodb-com/com-download-center/mongosh.multiversion.json
+    arch="x64"
+  fi
+
+  link="https://downloads.mongodb.com/compass/mongosh-$version-$dist-$arch.$ext"
+
+  log "downloading $link"
+  $GET "$link" -o $M_DIR/mongosh-$version.$ext
+
+  if test $? -gt 0; then
+    printf "Error: mongosh installation failed\n"
+    printf "  Fetch for MongoDB Shell version $version failed.\n"
+    printf "  Try a different version or view $logpath to view\n"
+    printf "  error details.\n"
+    printf "\n"
+    printf "You might also consider installing the MongoDB shell from the MongoDB Download Center:\n"
+    printf "  https://www.mongodb.com/try/download/shell\n"
+    exit 1
+  fi
+
+  mkdir -p $SHELL_DIR/$version
+
+  log "unpacking source"
+  if [[ $ext = "zip" ]]; then
+    unzip -q $M_DIR/mongosh-$version.zip -d $SHELL_DIR/$version
+  else
+    tar -xzf $M_DIR/mongosh-$version.tgz -C $SHELL_DIR/$version
+  fi
+
+
+  log "moving files"
+  mv $SHELL_DIR/$version/mongosh-$version-$dist-$arch/* $SHELL_DIR/$version
+
+  log "cleaning up"
+  rm $M_DIR/mongosh-$version.$ext
+  rm -r $SHELL_DIR/$version/mongosh-$version-$dist-$arch
+}
+
+#
+# Install and activate MongoDB Shell.
+#
+#   install_shell <version>
+#
+
+install_shell() {
+  local version=$1
+
+  check_current_shell_version
+  check_current_version
+
+  if [[ $version == $active_shell ]]; then
+    printf "Already Active: MongoDB Server $active, MongoDB Shell $active_shell\n"
+    exit 0
+  fi
+
+  if [[ $version =~ "rc" ]]; then
+    local rc="--rc"
+  fi
+
+  if [[ $version == "stable" ]]; then
+    # Need to fetch versions to find the latest
+    get_all_shell_versions $rc
+    if [[ -z "$versions" ]]; then
+      printf "Could not fetch available versions of MongoDB Shell\n"
+      exit 1
+    fi
+    # Set version to the latest available version
+    version=`echo $versions | awk 'NF>1{print $NF}'`
+  elif [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    # Specific version provided, try to install it directly
+    # (only validate if we successfully fetched versions)
+    get_all_shell_versions $rc
+    if [[ ! -z "$versions" ]] && [[ ! $versions =~ $version ]]; then
+      printf "Could not find any releases for the requested version "$version" of MongoDB Shell\n"
+      exit 1
+    fi
+  else
+    printf "Invalid version format: $version\n"
+    exit 1
+  fi
+
+  local dir=$SHELL_DIR/$version
+  if test ! -d $dir; then
+    prompt_install "MongoDB Shell version $version is not installed."
+    install_shell_bin $version
+  fi
+
+  log "activating MongoDB Shell $version"
+  debug "Shell path: $dir"
+  ln -fs $dir/bin/* $M_BIN_DIR
+
+  printf "Installation complete: MongoDB Shell $version activated!\n"
+}
+
 #
 # Install MongoDB <version> [config ...]
 #
 
 install_mongo() {
-
   local version=$1; shift
   local config=$@
   local rc=""
@@ -633,7 +974,7 @@ install_mongo() {
     abort "Could not find any releases for the requested version\n"
   fi
 
-  
+
   local dir=$VERSIONS_DIR/$version
   if ! test -d $dir; then
     # install
@@ -663,17 +1004,21 @@ install_mongo() {
   fi
   echo ""
   if vergte $version "6.0.0"; then
-    echo ""
-    echo "NOTE: the legacy mongo shell is not included in MongoDB 6.0+ distributions"
-    echo ""
-    echo "Download the new MongoDB Shell (mongosh):"
-    echo "   https://www.mongodb.com/try/download/shell"
-    echo ""
+    if ! command -v mongosh &> /dev/null; then
+      echo ""
+      echo "NOTE: the mongo shell is not included in MongoDB 6.0+ distributions."
+      echo ""
+      echo "Install and use the MongoDB Shell (mongosh) separately via:"
+      echo "   m shell stable"
+      echo ""
+      echo "Or download it directly from the MongoDB website:"
+      echo "   https://www.mongodb.com/try/download/shell"
+      echo ""
+    fi
   fi
 
 }
 
-#
 # Prompt installation
 #
 #   prompt_install "About to install something"
@@ -738,7 +1083,7 @@ install_bin() {
   fi
 
   # determine url based on os and arch
-  get_distro_and_arch
+  get_distro_and_arch 'server'
 
   # determine the download url
   if [[ "$community" == 1 ]]; then
@@ -815,6 +1160,16 @@ install_bin() {
 #
 
 get_distro_and_arch() {
+  local type=
+  case "$1" in
+    tools|server|shell)
+      type="$1"
+      ;;
+    *)
+      abort "Invalid type: '$1' (expected: tools, server, or shell)"
+      ;;
+  esac
+
   arch=`uname -m`
   local OS=`uname`
   os=`echo $OS | tr '[:upper:]' '[:lower:]'`
@@ -824,7 +1179,7 @@ get_distro_and_arch() {
       os=linux ;;
     darwin* )
       os=osx
-      if [ "$arch" = "arm64" ]; then
+      if [[ "$type" == "server" ]] && [ "$arch" = "arm64" ]; then
         if [ $(numeric_version $version) -lt $(numeric_version "6.0.0") ]; then
           echo ""
           echo "NOTE: Apple Silicon is not natively supported for MongoDB server before 6.0"
@@ -914,6 +1269,7 @@ get_distro_and_arch() {
     redhatenterpriseserver) distro_id="rhel" ;;
     rocky) distro_id="rhel" ;;
     neon) distro_id="ubuntu" ;;
+    pop) distro_id="ubuntu" ;;
   esac
 
   distro="$distro_id-$distro_version"
@@ -949,8 +1305,9 @@ get_distro_and_arch() {
     ubuntu-16*) distros="ubuntu1604 ubuntu1404" ;;
     ubuntu-18*) distros="ubuntu1804 ubuntu1604" ;;
     ubuntu-20*) distros="ubuntu2004 ubuntu1804" ;;
-    ubuntu-22*) distros="ubuntu2204 ubuntu2004 ubuntu1804" ;;
-    ubuntu-*)   distros="ubuntu2204 ubuntu2004" ;;
+    ubuntu-22*) distros="ubuntu2204 ubuntu2004 ubuntu1804" ;; # see #156
+    ubuntu-24*) distros="ubuntu2404 ubuntu2204 ubuntu2004 ubuntu1804" ;;
+    ubuntu-*)   distros="ubuntu2404 ubuntu2204 ubuntu2004" ;;
 
     linuxmint-17*) distros="ubuntu1404" ;;
     linuxmint-18*) distros="ubuntu1604" ;;
@@ -967,6 +1324,7 @@ get_distro_and_arch() {
     amzn-1) distros="$amazon1 rhel70 rhel62" ;;
     amzn-2018.03) distros="$amazon1 rhel70 rhel62" ;;
     amzn-2) distros="amazon2 $amazon1 rhel70 rhel62" ;;
+    amzn-2023) distros="amazon2023" ;;
     amzn-*) distros="amazon2 $amazon1" ;;
 
     rhel-5*) distros="rhel55 rhel57" ;;
@@ -1094,11 +1452,13 @@ remove_versions() {
     debug "=> Path: $rmpath"
     if test "$version" = "$active"; then
       printf "WARNING: $version is the active version!\n"
-      read -p "Are you sure you want to remove this? [y/N] " yn
-      case $yn in
-        [Yy]* ) ;;
-        * )  printf "SKIPPING $version "; exit;;
-      esac
+      if [[ "$CONFIRM" == 1 ]]; then
+        read -p "Are you sure you want to remove this? [y/N] " yn
+        case $yn in
+          [Yy]* ) ;;
+          * )  printf "SKIPPING $version "; exit;;
+        esac
+      fi
     fi
 
     if [ -d $rmpath ]; then
@@ -1210,15 +1570,24 @@ execute_shard_with_version() {
 
 execute_shell_with_version() {
   test -z $1 && abort "version required"
-  local version=$(get_latest_installed_version ${1#v})
-  local bin=$VERSIONS_DIR/$version/bin/mongo
+
+  # first see if this version of mongosh is installed. fallback to legacy.
+  local bin=$SHELL_DIR/${1#v}/bin/mongosh
+
+  if ! test -f $bin; then
+    log "mongosh version ${1#v} not found, falling back to legacy mongo shell"
+    local version=$(get_latest_installed_version ${1#v})
+    local bin=$VERSIONS_DIR/$version/bin/mongo
+  fi
+
+  debug "Shell bin: $bin"
 
   shift # remove version
 
   if test -f $bin; then
     $bin $@
   else
-    abort_not_installed $version
+    abort_shell_not_installed ${1#v}
   fi
 }
 
@@ -1234,10 +1603,11 @@ display_latest_version() {
 
   if [[ $version =~ ^[0-9]\.[0-9]+$ ]]; then
     echo $all_versions \
-      | grep -E -o "$version\.[0-9]+([-_\.]rc[0-9]+)?" \
-      | grep -E -v "\d-\d" \
-      | uniq \
+      | grep -Eo "version\":[[:space:]]*\"$version\.[0-9]+([-_\.]rc[0-9]+)?" \
+      | sed 's/version\":[[:space:]]*\"//' \
+      | grep -Ev "\d-\d" \
       | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
+      | uniq \
       | tail -n1
   else
     if [[ ! -z "$version" ]]; then
@@ -1266,18 +1636,20 @@ display_latest_stable_version() {
   if [[ $version =~ ^[0-4]\.[0246]+$ ]]; then
     debug "Stable version < 5.0 ($version) is X.Y (Y is even)"
     echo $all_versions \
-      | grep -E -o "$version\.[0-9]+" \
+      | grep -Eo "version\":[[:space:]]*\"($version\.[0-9]+)" \
+      | sed 's/version\":[[:space:]]*\"//' \
       | grep -E -v "\d-\d" \
-      | uniq \
       | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
+      | uniq \
       | tail -n1
   elif [[ $version =~ ^[5-9]\.0$ ]]; then
     debug "Stable version >= 5.0 ($version) is X.0"
     echo $all_versions \
-      | grep -E -o "$version\.[0-9]+" \
+      | grep -Eo "version\":[[:space:]]*\"($version\.[0-9]+)" \
+      | sed 's/version\":[[:space:]]*\"//' \
       | grep -E -v "\d-\d" \
-      | uniq \
       | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
+      | uniq \
       | tail -n1
   else
     if [[ ! -z "$version" ]]; then
@@ -1335,7 +1707,7 @@ list_versions() {
 
   for v in $versions; do
     if test "$active" = "$v"; then
-      printf "  ο $v\n"
+      printf "  ✔ $v\n"
     else
       if test -d $VERSIONS_DIR/$v; then
         printf "  * $v\n"
@@ -1492,12 +1864,33 @@ list_posts() {
 # Handle tools commands
 
 handle_tools() {
-  case $1 in
-      ls|list|available|avail) list_tools_versions $@; exit;;
-      lls|installed) display_tools_versions $2; exit ;;
-      stable) install_tools $@; exit ;;
-      *) install_tools $@; exit ;;
-    esac
+  if test $# -eq 0; then
+    display_tools_versions
+  else
+    case $1 in
+        ls|list|available|avail) list_tools_versions $@; exit;;
+        lls|installed) display_tools_versions $2; exit ;;
+        stable) install_tools $@; exit ;;
+        rm) shift; remove_tools_versions $@; exit ;;
+        *) install_tools $@; exit ;;
+      esac
+  fi
+}
+
+# Handle mongosh commands
+
+handle_mongosh() {
+  if test $# -eq 0; then
+    display_shell_versions
+  else
+    case $1 in
+        ls|list|available|avail) list_shell_versions $@; exit;;
+        lls|installed) display_shell_versions $2; exit ;;
+        stable) install_shell $@; exit ;;
+        rm) shift; remove_shell_versions $@; exit ;;
+        *) install_shell $@; exit ;;
+      esac
+  fi
 }
 
 # Handle arguments
@@ -1526,6 +1919,7 @@ else
       install) shift; install_mongo $@; exit ;;
       reinstall) shift; CONFIRM=0; remove_versions $@; install_mongo $@; exit;;
       tools) shift; handle_tools $@; exit;;
+      mongosh) shift; handle_mongosh $@; exit;;
       *) install_mongo $@; exit ;;
     esac
     shift

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 TOOL_NAME="mongodb"
-TOOL_TEST="mongodb --help"
+TOOL_TEST="mongod --help"
 
 current_script_path=${BASH_SOURCE[0]}
 util_dir=$(dirname "$current_script_path")
@@ -12,8 +12,6 @@ fail() {
 	echo -e "asdf-$TOOL_NAME: $*"
 	exit 1
 }
-
-curl_opts=(-fsSL)
 
 sort_versions() {
 	sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
@@ -28,39 +26,27 @@ list_stable_version() {
 	"$util_dir/m" --stable
 }
 
-download_release() {
-	local version filename url
-	version="$1"
-	filename="$2"
-
-	# TODO: Adapt the release URL convention for mongodb
-	# url="$GH_REPO/archive/v${version}.tar.gz"
-
-	# echo "* Downloading $TOOL_NAME release $version..."
-	# curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
-}
-
 install_version() {
 	local install_type="$1"
 	local version="$2"
-	local install_path="${3%/bin}/bin"
+	local install_path="$3"
 
 	if [ "$install_type" != "version" ]; then
 		fail "asdf-$TOOL_NAME supports release installs only"
 	fi
 
-	(
-		mkdir -p "$install_path"
-		cp -r "$ASDF_DOWNLOAD_PATH"/* "$install_path"
-
-		# TODO: Assert mongodb executable exists.
-		local tool_cmd
-		tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
-		test -x "$install_path/$tool_cmd" || fail "Expected $install_path/$tool_cmd to be executable."
-
-		echo "$TOOL_NAME $version installation was successful!"
-	) || (
-		rm -rf "$install_path"
+	# lib/m respects M_PREFIX to determine where to install.
+	# Setting it to $install_path causes m to place binaries at:
+	#   $install_path/m/versions/<version>/bin/   (versioned copy)
+	#   $install_path/bin/                        (symlinks, on PATH via asdf)
+	# M_CONFIRM=0 disables the interactive download confirmation prompt.
+	M_PREFIX="$install_path" M_CONFIRM=0 "$util_dir/m" "$version" ||
 		fail "An error occurred while installing $TOOL_NAME $version."
-	)
+
+	local tool_cmd
+	tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
+	test -x "$install_path/bin/$tool_cmd" ||
+		fail "Expected $install_path/bin/$tool_cmd to be executable."
+
+	echo "$TOOL_NAME $version installation was successful!"
 }

--- a/scripts/update-m.bash
+++ b/scripts/update-m.bash
@@ -1,22 +1,33 @@
 #!/usr/bin/env bash
 
-if [ -z "$GITHUB_API_TOKEN" ]; then
-	echo "This script requires environment variable GITHUB_API_TOKEN"
+auth_header=()
+if [ -n "${GITHUB_API_TOKEN:-}" ]; then
+	auth_header=(-H "Authorization: Bearer $GITHUB_API_TOKEN")
+fi
+
+latestVersion=$(curl -sL \
+	-H "Accept: application/vnd.github+json" \
+	"${auth_header[@]}" \
+	https://api.github.com/repos/aheckmann/m/commits/master |
+	grep '"sha"' | head -n1 | sed -E 's/.*"sha": "([0-9a-f]+)".*/\1/')
+
+if [ -z "$latestVersion" ]; then
+	echo "Failed to fetch latest commit SHA (rate limited? Set GITHUB_API_TOKEN to authenticate)"
 	exit 1
 fi
 
-latestVersion=$(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_API_TOKEN" -L https://api.github.com/repos/aheckmann/m/commits/master | grep sha | head -n1 | sed -E 's/.*"sha": "([0-9a-f]+)".*/\1/')
+echo "Updating lib/m to $latestVersion..."
 
-curl https://raw.githubusercontent.com/aheckmann/m/master/bin/m | awk -v version="$latestVersion" '
+curl -sL "https://raw.githubusercontent.com/aheckmann/m/$latestVersion/bin/m" | awk -v version="$latestVersion" '
 BEGIN {
     print "#!/usr/bin/env bash"
     print "# shellcheck disable=all"
     printf "# Copied from hash %s of https://github.com/aheckmann/m\n", version
-    # Skip the first line of the original input
     getline
 }
 {
-    # Print the rest of the lines as they are
     print
 }' >lib/m
 chmod +x lib/m
+
+echo "Done. lib/m updated to $latestVersion"


### PR DESCRIPTION
## Summary

This PR updates the asdf-mongodb plugin to support MongoDB Shell (mongosh) installation and management alongside the existing MongoDB server and tools support. It also updates the underlying `m` version manager from v1.8.9 to v1.10.0.

## Key Changes

- **MongoDB Shell Support**: Added complete mongosh installation and management functionality:
  - New `handle_mongosh()` command handler for `m mongosh` operations
  - `install_shell()` and `install_shell_bin()` functions to download and install mongosh binaries
  - `check_current_shell_version()` to detect active mongosh version
  - `get_all_shell_versions()` to fetch available versions from GitHub
  - `display_shell_versions()` and `list_shell_versions()` for version listing
  - `remove_shell_versions()` to uninstall mongosh versions
  - New `SHELL_DIR` configuration for mongosh binary storage

- **Updated m Version Manager**: Upgraded from v1.8.9 to v1.10.0 with improvements:
  - Enhanced curl options (`-sSLf` instead of `-s -L`)
  - Better GitHub API token support for rate limiting
  - Improved distro detection (added Pop!_OS, Amazon Linux 2023, Ubuntu 24.04)
  - Fixed enterprise version detection regex
  - Better error handling and validation

- **Tools Management Enhancements**:
  - Added `remove_tools_versions()` function for removing Database Tools
  - Improved architecture detection for Apple Silicon with version-specific handling
  - Better error messages and installation feedback

- **Plugin Infrastructure Updates**:
  - Added new help scripts: `help.overview`, `help.links`, `help.deps`, `post-plugin-add`
  - Added `bin/uninstall` script for proper cleanup
  - Updated `bin/download` to be a no-op (m handles downloading)
  - Fixed test command from `mongodb --help` to `mongod --help`
  - Updated `lib/utils.bash` to use m directly for installation

- **Documentation & UX Improvements**:
  - Updated help text with mongosh commands
  - Changed version indicator from `*` to `✔` for active versions
  - Updated example versions from 3.6 to 7.0 in help text
  - Improved README with better description and dependencies list
  - Added GitHub token support for API requests to avoid rate limiting

- **Bug Fixes**:
  - Fixed shell execution to check mongosh first, then fallback to legacy mongo shell
  - Improved version detection and validation
  - Better handling of RC (release candidate) versions
  - Fixed file extraction and cleanup logic

## Notable Implementation Details

- The mongosh installation uses the same pattern as tools installation, downloading from `downloads.mongodb.com`
- Architecture naming differs between components (x86_64 → x64 for mongosh)
- The plugin now properly integrates with asdf's install/uninstall lifecycle
- GitHub API requests include optional token authentication to handle rate limiting

https://claude.ai/code/session_01LAmsfLyBtrPdREdZm3NKsJ